### PR TITLE
Fix create-ae dialog text

### DIFF
--- a/dcm4chee-arc-ui2/src/app/widgets/dialogs/create-ae/create-ae.component.html
+++ b/dcm4chee-arc-ui2/src/app/widgets/dialogs/create-ae/create-ae.component.html
@@ -89,7 +89,7 @@
                                         <span>False</span>
                                     </label>
                                 </div>
-                                <span class="description checkbox">A unique name for this device</span>
+                                <span class="description checkbox">Boolean to indicate whether this device is presently installed on the network</span>
                             </div>
                         </div>
                         <h4 (click)="showconn=!showconn;showdevice=false">New Network Connection  <span *ngIf="newAetModel && newAetModel.dicomNetworkConnection && newAetModel.dicomNetworkConnection[0] && newAetModel.dicomNetworkConnection[0].cn"> <b>{{newAetModel.dicomNetworkConnection[0].cn}}</b></span></h4>


### PR DESCRIPTION
The 'A unique name for this device' text was duplicated, also written on the "Installed" option. I corrected it with the same text that can be found on the Swagger description for that option.

![unique](https://user-images.githubusercontent.com/2430915/63884711-ff9a5700-c9d6-11e9-9c2e-63bac33d7665.png)
