### PR TITLE
Rtirabassi uid map oom

### DIFF
--- a/dcm4chee-arc-audit/pom.xml
+++ b/dcm4chee-arc-audit/pom.xml
@@ -84,12 +84,6 @@
     </dependency>
     <dependency>
       <groupId>org.dcm4che.dcm4chee-arc</groupId>
-      <artifactId>dcm4chee-arc-keycloak</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.dcm4che.dcm4chee-arc</groupId>
       <artifactId>dcm4chee-arc-patient</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/dcm4chee-arc-delete/src/main/java/org/dcm4chee/arc/delete/impl/DeletionServiceEJB.java
+++ b/dcm4chee-arc-delete/src/main/java/org/dcm4chee/arc/delete/impl/DeletionServiceEJB.java
@@ -516,6 +516,14 @@ public class DeletionServiceEJB {
                 .getSingleResult() > 0;
     }
 
+    public boolean hasInUseFile(String storageID, String storagePath) {
+        return em.createNamedQuery(Location.COUNT_IN_USE_FILES, Long.class)
+                .setParameter(1, storageID)
+                .setParameter(2, Location.Status.OK)
+                .setParameter(3, storagePath)
+                .getSingleResult() > 0;
+    }
+
     private long countStudiesOfPatient(Patient patient) {
         return em.createNamedQuery(Study.COUNT_STUDIES_OF_PATIENT, Long.class).setParameter(1, patient)
                 .getSingleResult();

--- a/dcm4chee-arc-delete/src/main/java/org/dcm4chee/arc/delete/impl/PurgeStorageScheduler.java
+++ b/dcm4chee-arc-delete/src/main/java/org/dcm4chee/arc/delete/impl/PurgeStorageScheduler.java
@@ -502,7 +502,13 @@ public class PurgeStorageScheduler extends Scheduler {
     private void deleteLocation(Storage storage, Location location, AtomicInteger success, AtomicInteger skipped) {
         try {
             if (ejb.claimDeleteObject(location)) {
-                storage.deleteObject(location.getStoragePath());
+                if ( !ejb.hasInUseFile(location.getStorageID(), location.getStoragePath()) ) {
+                    // File can actually be removed since not used in any other valid location
+                    storage.deleteObject(location.getStoragePath());
+                }
+                else {
+                    LOG.debug("Location {} deleted from {}, but file is still in use", location, storage);
+                }
                 ejb.removeLocation(location);
                 LOG.debug("Successfully delete {} from {}", location, storage);
                 success.getAndIncrement();

--- a/dcm4chee-arc-entity/src/main/java/org/dcm4chee/arc/entity/Location.java
+++ b/dcm4chee-arc-entity/src/main/java/org/dcm4chee/arc/entity/Location.java
@@ -57,6 +57,8 @@ import java.util.Date;
     @Index(columnList = "multi_ref")
 })
 @NamedQueries({
+        @NamedQuery(name = Location.COUNT_IN_USE_FILES,
+                query = "select count(l) from Location l where l.storageID=?1 and l.status=?2 and l.storagePath=?3"),
         @NamedQuery(name = Location.FIND_BY_STORAGE_ID_AND_STATUS,
                 query = "select l from Location l where l.storageID=?1 and l.status=?2"),
         @NamedQuery(name = Location.FIND_BY_STUDY_PK,
@@ -125,6 +127,7 @@ import java.util.Date;
 })
 public class Location {
 
+    public static final String COUNT_IN_USE_FILES = "Location.CountInUseFiles";
     public static final String FIND_BY_STORAGE_ID_AND_STATUS = "Location.FindByStorageIDAndStatus";
     public static final String FIND_BY_STUDY_PK = "Location.FindByStudyPk";
     public static final String FIND_BY_SERIES_PK = "Location.FindBySeriesPk";

--- a/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/RetrieveService.java
+++ b/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/RetrieveService.java
@@ -53,8 +53,9 @@ import org.dcm4che3.net.service.QueryRetrieveLevel2;
 import org.dcm4chee.arc.conf.ArchiveAEExtension;
 import org.dcm4chee.arc.conf.ArchiveDeviceExtension;
 import org.dcm4chee.arc.entity.Series;
-import org.dcm4chee.arc.metrics.MetricsService;
+import org.dcm4chee.arc.entity.UIDMap;
 import org.dcm4chee.arc.keycloak.HttpServletRequestInfo;
+import org.dcm4chee.arc.metrics.MetricsService;
 import org.dcm4chee.arc.storage.Storage;
 import org.dcm4chee.arc.store.InstanceLocations;
 import org.dcm4chee.arc.store.StoreService;
@@ -85,7 +86,7 @@ public interface RetrieveService {
                                           Association as, Attributes cmd, QueryRetrieveLevel2 qrLevel, Attributes keys);
 
     RetrieveContext newRetrieveContextMOVE(ArchiveAEExtension arcAE,
-            Association as, Attributes cmd, QueryRetrieveLevel2 qrLevel, Attributes keys)
+                                           Association as, Attributes cmd, QueryRetrieveLevel2 qrLevel, Attributes keys)
             throws ConfigurationException;
 
     RetrieveContext newRetrieveContextWADO(
@@ -149,4 +150,6 @@ public interface RetrieveService {
     Date getLastModifiedFromMatches(RetrieveContext ctx);
 
     Date getLastModified(RetrieveContext ctx);
+
+    UIDMap getUIDMap(Long uidMapPk, Map<Long, UIDMap> uidMapCache);
 }

--- a/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/LocationQuery.java
+++ b/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/LocationQuery.java
@@ -139,6 +139,7 @@ class LocationQuery {
                 locationPath.get(Location_.digest),
                 locationPath.get(Location_.size),
                 locationPath.get(Location_.status),
+                locationPath.get(Location_.multiReference),
                 series.get(Series_.pk),
                 instance.get(Instance_.pk),
                 instance.get(Instance_.retrieveAETs),
@@ -147,7 +148,6 @@ class LocationQuery {
                 instance.get(Instance_.createdTime),
                 instance.get(Instance_.updatedTime),
                 uidMap.get(UIDMap_.pk),
-                // uidMap.get(UIDMap_.encodedMap),
                 instanceAttrBlob
         );
     }
@@ -241,6 +241,7 @@ class LocationQuery {
                 .size(tuple.get(locationPath.get(Location_.size)))
                 .status(tuple.get(locationPath.get(Location_.status)))
                 .build();
+        location.setMultiReference(tuple.get(locationPath.get(Location_.multiReference))) ;
         Long uidMapPk = tuple.get(uidMap.get(UIDMap_.pk));
         if (uidMapPk != null) {
             location.setUidMap(ctx.getRetrieveService().getUIDMap(uidMapPk, uidMapCache));

--- a/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/RetrieveContextImpl.java
+++ b/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/RetrieveContextImpl.java
@@ -52,9 +52,12 @@ import org.dcm4che3.util.StringUtils;
 import org.dcm4chee.arc.conf.*;
 import org.dcm4chee.arc.entity.Location;
 import org.dcm4chee.arc.entity.Series;
-import org.dcm4chee.arc.retrieve.*;
-import org.dcm4chee.arc.storage.Storage;
 import org.dcm4chee.arc.keycloak.HttpServletRequestInfo;
+import org.dcm4chee.arc.retrieve.RetrieveContext;
+import org.dcm4chee.arc.retrieve.RetrieveService;
+import org.dcm4chee.arc.retrieve.SeriesInfo;
+import org.dcm4chee.arc.retrieve.StudyInfo;
+import org.dcm4chee.arc.storage.Storage;
 import org.dcm4chee.arc.store.InstanceLocations;
 import org.dcm4chee.arc.store.UpdateLocation;
 

--- a/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/RetrieveServiceEJB.java
+++ b/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/RetrieveServiceEJB.java
@@ -43,11 +43,13 @@ package org.dcm4chee.arc.retrieve.impl;
 import org.dcm4chee.arc.entity.Completeness;
 import org.dcm4chee.arc.entity.Series;
 import org.dcm4chee.arc.entity.Study;
+import org.dcm4chee.arc.entity.UIDMap;
 import org.dcm4chee.arc.retrieve.RetrieveContext;
 
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.util.Map;
 
 /**
  * @author Gunter Zeilinger <gunterze@gmail.com>
@@ -85,6 +87,15 @@ public class RetrieveServiceEJB {
                 setCompletenessOfStudy(studyIUIDs[0], Completeness.UNKNOWN);
                 break;
         }
+    }
+
+    public UIDMap getUIDMapReference(Long uidMapPk, Map<Long, UIDMap> uidMapCache) {
+        UIDMap uidMap = uidMapCache.get(uidMapPk) ;
+        if ( null == uidMap ) {
+            uidMap = em.find(UIDMap.class, uidMapPk) ;
+            uidMapCache.put(uidMapPk, uidMap) ;
+        }
+        return uidMap;
     }
 
     private void setCompletenessOfStudy(String studyInstanceUID, Completeness completeness) {

--- a/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/RetrieveServiceImpl.java
+++ b/dcm4chee-arc-retrieve/src/main/java/org/dcm4chee/arc/retrieve/impl/RetrieveServiceImpl.java
@@ -58,8 +58,8 @@ import org.dcm4chee.arc.LeadingCFindSCPQueryCache;
 import org.dcm4chee.arc.code.CodeCache;
 import org.dcm4chee.arc.conf.*;
 import org.dcm4chee.arc.entity.*;
-import org.dcm4chee.arc.metrics.MetricsService;
 import org.dcm4chee.arc.keycloak.HttpServletRequestInfo;
+import org.dcm4chee.arc.metrics.MetricsService;
 import org.dcm4chee.arc.query.scu.CFindSCU;
 import org.dcm4chee.arc.query.scu.CFindSCUAttributeCoercion;
 import org.dcm4chee.arc.query.util.QueryBuilder;
@@ -153,7 +153,7 @@ public class RetrieveServiceImpl implements RetrieveService {
 
     @Override
     public RetrieveContext newRetrieveContextGET(ArchiveAEExtension arcAE,
-            Association as, Attributes rqCmd, QueryRetrieveLevel2 qrLevel, Attributes keys) {
+                                                 Association as, Attributes rqCmd, QueryRetrieveLevel2 qrLevel, Attributes keys) {
         RetrieveContext ctx = newRetrieveContext(arcAE, as, qrLevel, keys);
         ctx.setPriority(rqCmd.getInt(Tag.Priority, 0));
         ctx.setDestinationAETitle(as.getRemoteAET());
@@ -162,7 +162,7 @@ public class RetrieveServiceImpl implements RetrieveService {
 
     @Override
     public RetrieveContext newRetrieveContextMOVE(ArchiveAEExtension arcAE,
-            Association as, Attributes rqCmd, QueryRetrieveLevel2 qrLevel, Attributes keys)
+                                                  Association as, Attributes rqCmd, QueryRetrieveLevel2 qrLevel, Attributes keys)
             throws ConfigurationException {
         RetrieveContext ctx = newRetrieveContext(arcAE, as, qrLevel, keys);
         ctx.setPriority(rqCmd.getInt(Tag.Priority, 0));
@@ -321,7 +321,7 @@ public class RetrieveServiceImpl implements RetrieveService {
         Collection<InstanceLocations> matches = ctx.getMatches();
         matches.clear();
         try {
-            HashMap<Long,StudyInfo> studyInfoMap = new HashMap<>();
+            HashMap<Long, StudyInfo> studyInfoMap = new HashMap<>();
             Series.MetadataUpdate metadataUpdate = ctx.getSeriesMetadataUpdate();
             if (metadataUpdate != null && metadataUpdate.instancePurgeState == Series.InstancePurgeState.PURGED) {
                 SeriesAttributes seriesAttributes = new SeriesAttributes(em, cb, metadataUpdate.seriesPk);
@@ -981,5 +981,10 @@ public class RetrieveServiceImpl implements RetrieveService {
             }
         }
         return attrs;
+    }
+
+    @Override
+    public UIDMap getUIDMap(Long uidMapPk, Map<Long, UIDMap> uidMapCache) {
+        return ejb.getUIDMapReference(uidMapPk, uidMapCache);
     }
 }

--- a/dcm4chee-arc-store/src/main/java/org/dcm4chee/arc/store/impl/StoreServiceEJB.java
+++ b/dcm4chee-arc-store/src/main/java/org/dcm4chee/arc/store/impl/StoreServiceEJB.java
@@ -1503,7 +1503,13 @@ public class StoreServiceEJB {
             Location prevLocation, Instance instance, Map<String, String> uidMap, Map<Long, UIDMap> uidMapCache) {
         if (prevLocation.getMultiReference() == null) {
             prevLocation = em.find(Location.class, prevLocation.getPk());
-            prevLocation.setMultiReference(idService.newLocationMultiReference());
+            // Since Location members could have been populated by a query result, not containing multiReference value,
+            // the location itself is now reloaded.
+            // This means that prevLocation.getMultiReference() can now return a non null value.
+            // That's why check must be done again before assigning a new value.
+            if (prevLocation.getMultiReference() == null) {
+                prevLocation.setMultiReference(idService.newLocationMultiReference());
+            }
         }
         Location newLocation = new Location(prevLocation);
         newLocation.setUidMap(createUIDMap(uidMap, prevLocation.getUidMap(), uidMapCache));


### PR DESCRIPTION
Dear Gunter,
I made some changes (starting from 5.21.0) to solve the following problems.
Since I'm novice to dcm4chee-arc-light (and to DICOM world too) please forgive me if my terms are uncorrect.

1) Suppose to have a study with a large amount (say > 1000) of instances (and relative locations). Than suppose to move this study from a patient to another. A single UIDMap is created to collect all ID changes.
Now let's export this study (e.g. using movescu) from this PACS to another.
The LocationQuery collects many columns and the UIDMap column too (> 1000 times). This cause the query execution to run OutOfMemory. So I removed the UIDMap column from the query and applied a simple cache to reuse each UIDMap (normally 1, if study in not copied more than once) in every location that is created from the query result.

2) Let's move a study from a patient to another with a 'Incorrect MWL Entry' reject type.
DICOM File is now referenced  from more than one Instance (so, more than one location): the one corresponding to original patient (but in rejected state) and the new one. Both of the locations are marked with a multiReference ID.
Now move that study again, back to the same patient or to another one, with same reject type.
The DICOM File is now referenced from three locations: two of them are in rejected state and just one is actually "valid" (as supposed).
Here's the scenario, now let's see what the problem is.
Deleting permanently the rejected instances cause the valid DICOM File to be removed.
This is due to:
a.1) When location is copied the second time, the multiReference field is not populated since location has not been loaded from the DB but built during LocationQuery execution. So the StoreServiceEJB.copyLocation() first checks for multiReference presence, than loads the location from DB... but doesn' t check it again. This means that newLocationMultiReference() is called on pevious location (and value is then assigned to the new one) substituting the existing value and breaking the multiReference chain. This way, the second and third location will share the same multiReference ID but the first one will preserve a different one and can be "Marked for Deletion" (while other ones are simply removed until the chain has more than 1 ring). The removed file will also affect remaining instances/locations and the corresponding DICOM File is lost forever.
Checking again multiReference value after location reload before assigning a new ID keeps the multiReference chain safe.
a.2) Since the multiReference ID is a simple Integer value, I also added it to the LocationQuery columns  in order to have that value pre-loaded and avoid reloading the location from DB during copy activity. I think this could fasten up copy process, but 'a.1' extra check is safer anyway.
b) When a location (and it's DICOM file) is candidate for deletion, according to what said at point 'a.1', corresponding DICOM file is removed with no other checks. This leads to a loss of file related to valid locations in this example, expecially before I find and solved point 'a.1'. In order not to risk to loose a file for any reason, I added a 'hasInUseFile()' check to avoid deletion of a "still in use" file.

3) This is a feature request: when study is moved as in previous examples, metadata only are still available in the old study. I still can walk the path up to the instance and see metadata, but I can also ask to "View DICOM File" that does not contain PIxelData anymore.
The result is a new blank tab in the browser telling something went wrong.
I suppose the corresponding button could be disalbed or hide.

Thanks in advance.