### PR TITLE
Parameterize auditlog role and realm

### DIFF
--- a/dcm4chee-arr-proxy/src/main/webapp-secure/WEB-INF/web.xml
+++ b/dcm4chee-arr-proxy/src/main/webapp-secure/WEB-INF/web.xml
@@ -53,14 +53,14 @@
       <url-pattern>/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
-      <role-name>auditlog</role-name>
+      <role-name>${audit-user-role:auditlog}</role-name>
     </auth-constraint>
   </security-constraint>
   <login-config>
     <auth-method>KEYCLOAK</auth-method>
-    <realm-name>dcm4che</realm-name>
+    <realm-name>${realm-name:dcm4che}</realm-name>
   </login-config>
   <security-role>
-    <role-name>auditlog</role-name>
+    <role-name>${audit-user-role:auditlog}</role-name>
   </security-role>
 </web-app>

--- a/dcm4chee-arr-proxy/src/main/webapp/WEB-INF/web.xml
+++ b/dcm4chee-arr-proxy/src/main/webapp/WEB-INF/web.xml
@@ -54,15 +54,15 @@
       <url-pattern>/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
-      <role-name>auditlog</role-name>
+      <role-name>${audit-user-role:auditlog}</role-name>
     </auth-constraint>
   </security-constraint>
   <login-config>
     <auth-method>KEYCLOAK</auth-method>
-    <realm-name>dcm4che</realm-name>
+    <realm-name>${realm-name:dcm4che}</realm-name>
   </login-config>
   <security-role>
-    <role-name>auditlog</role-name>
+    <role-name>${audit-user-role:auditlog}</role-name>
   </security-role>
   -->
 </web-app>

--- a/dcm4chee-arr-query/src/main/webapp-secure/WEB-INF/web.xml
+++ b/dcm4chee-arr-query/src/main/webapp-secure/WEB-INF/web.xml
@@ -50,14 +50,14 @@
       <url-pattern>/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
-      <role-name>user</role-name>
+      <role-name>${auth-user-role:user}</role-name>
     </auth-constraint>
   </security-constraint>
   <login-config>
     <auth-method>KEYCLOAK</auth-method>
-    <realm-name>dcm4che</realm-name>
+    <realm-name>${realm-name:dcm4che}</realm-name>
   </login-config>
   <security-role>
-    <role-name>user</role-name>
+    <role-name>${auth-user-role:user}</role-name>
   </security-role>
 </web-app>

--- a/dcm4chee-arr-query/src/main/webapp/WEB-INF/web.xml
+++ b/dcm4chee-arr-query/src/main/webapp/WEB-INF/web.xml
@@ -51,15 +51,15 @@
       <url-pattern>/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
-      <role-name>user</role-name>
+      <role-name>${auth-user-role:user}</role-name>
     </auth-constraint>
   </security-constraint>
   <login-config>
     <auth-method>KEYCLOAK</auth-method>
-    <realm-name>dcm4che</realm-name>
+    <realm-name>${realm-name:dcm4che}</realm-name>
   </login-config>
   <security-role>
-    <role-name>user</role-name>
+    <role-name>${auth-user-role:user}</role-name>
   </security-role>
   -->
 </web-app>


### PR DESCRIPTION
- Allow parameterization of `auditlog` security role using `audit-user-role` as for `super-user-role` and `auth-user-role`.
- Changed hard-coded realm-name to use parameter `realm-name`.