### PR TITLE
Delete orphaned bulk data files

### DIFF
--- a/dcm4chee-arc-store/src/main/java/org/dcm4chee/arc/store/impl/StoreServiceImpl.java
+++ b/dcm4chee-arc-store/src/main/java/org/dcm4chee/arc/store/impl/StoreServiceImpl.java
@@ -219,7 +219,6 @@ class StoreServiceImpl implements StoreService {
     }
 
     private void writeToStorage(StoreContext ctx, InputStream data) throws DicomServiceException {
-        List<File> bulkDataFiles = Collections.emptyList();
         String receiveTranferSyntax = ctx.getReceiveTranferSyntax();
         ArchiveAEExtension arcAE = ctx.getStoreSession().getArchiveAEExtension();
         ArchiveDeviceExtension arcDev = arcAE.getArchiveDeviceExtension();
@@ -234,18 +233,14 @@ class StoreServiceImpl implements StoreService {
             transcoder.setBulkDataDirectory(arcAE.getBulkDataSpoolDirectoryFile());
             transcoder.setIncludeFileMetaInformation(true);
             transcoder.setIncludeImplementationVersionName(arcDev.isStoreImplementationVersionName());
-            transcoder.setDeleteBulkDataFiles(false);
+            transcoder.setDeleteBulkDataFiles(true);
             transcoder.transcode(new TranscoderHandler(ctx));
-            bulkDataFiles = transcoder.getBulkDataFiles();
         } catch (StorageException e) {
             LOG.warn("{}: Failed to store received object:\n", ctx.getStoreSession(), e);
             throw new DicomServiceException(Status.OutOfResources, e);
         } catch (Throwable e) {
             LOG.warn("{}: Failed to store received object:\n", ctx.getStoreSession(), e);
             throw new DicomServiceException(Status.ProcessingFailure, e);
-        } finally {
-            for (File tmpFile : bulkDataFiles)
-                tmpFile.delete();
         }
     }
 


### PR DESCRIPTION
Ensure bulk data files are cleaned up on storage write failures

Resolves #3251

`writeToStorage` method of `org.dcm4chee.arc.store.impl.StoreServiceImpl` is invoked on C-STORE. In it, `org.dcm4che3.imagio.codec.Transcoder` is used, which writes bulk data into temporary files. These are meant to be deleted on successful writes to the filesystem, but are not appropriately cleaned up if an exception is raised in `transcode`.

As far as I can tell, simply setting `setDeleteBulkDataFiles` to true and allowing  `org.dcm4che3.imagio.codec.Transcoder` to clean up after itself produces no undesirable side effects. Either way, deleting files explicitly in a `finally` block won't work if there's an exception before `bulkDataFiles` is populated with an up-to-date list of files to delete.

 I confirmed that applying this patch resolves the orphan bulk data files problem.