### PR TITLE
FIX typo in expiration key name UPDATEABLE

### DIFF
--- a/dcm4chee-arc-ui2/src/app/constants/globalvar.ts
+++ b/dcm4chee-arc-ui2/src/app/constants/globalvar.ts
@@ -4755,7 +4755,7 @@ export class Globalvar {
                     filterKey:"ExpirationState",
                     showStar:true,
                     options:[
-                        new SelectDropdown("UPDATABLE", $localize `:@@UPDATABLE:UPDATABLE`, $localize `:@@expiration_state_updateable:No expiration date set to study`),
+                        new SelectDropdown("UPDATEABLE", $localize `:@@UPDATEABLE:UPDATEABLE`, $localize `:@@expiration_state_updateable:No expiration date set to study`),
                         new SelectDropdown("FROZEN", $localize `:@@FROZEN:FROZEN`, $localize `:@@expiration_state_frozen:Study protected from being expired`),
                         new SelectDropdown("REJECTED", $localize `:@@REJECTED:REJECTED`, $localize `:@@expiration_state_rejected:Rejected expired studies`),
                         new SelectDropdown("EXPORT_SCHEDULED", $localize `:@@EXPORT_SCHEDULED:EXPORT_SCHEDULED`, $localize `:@@expiration_state_export_scheduled:Export scheduled for expired studies before rejecting them`),


### PR DESCRIPTION
According the Java model enum: [enum ExpirationState](https://github.com/dcm4che/dcm4chee-arc-light/blob/84bcfd1929d3a5d48e1555aa4d385fa07b2dbf1f/dcm4chee-arc-entity/src/main/java/org/dcm4chee/arc/entity/ExpirationState.java#L49)

the value must be: UPDATEABLE, FROZEN, REJECTED,  EXPORT_SCHEDULED, FAILED_TO_EXPORT, FAILED_TO_REJECT

however front sends the wrong value: UPDATABLE and error has being raised:

```json
{
    "exception": null,
    "propertyViolations": [
        {
            "constraintType": "PROPERTY",
            "path": "expirationState",
            "message": "must match \"UPDATEABLE|FROZEN|REJECTED|EXPORT_SCHEDULED|FAILED_TO_EXPORT|FAILED_TO_REJECT\"",
            "value": "UPDATABLE"
        }
    ],
    "classViolations": [],
    "parameterViolations": [],
    "returnValueViolations": []
}
```
<img width="961" alt="Screenshot 2025-02-03 at 14 09 36" src="https://github.com/user-attachments/assets/0c1b551c-ac32-44e2-9371-e80c3d3f9eb6" />


